### PR TITLE
Use Travis CI for building Tomcat Connectors on ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dist: bionic
+compiler: gcc
+arch: arm64
+
+addons:
+    apt:
+      packages:
+        - build-essential
+        - automake
+        - autoconf
+        - tar
+        - libssl-dev
+        - subversion
+        - git
+        - libtool-bin
+
+before_script:
+    - rm -rf $HOME/tmp
+    - mkdir $HOME/tmp
+    - export CURR_PWD=`pwd`
+    - echo "Going to build APR"
+    - svn co -q https://svn.apache.org/repos/asf/apr/apr/branches/1.7.x/ $HOME/tmp/apr
+    - cd $HOME/tmp/apr
+    - ./buildconf
+    - ./configure --prefix=$HOME/tmp/apr-build
+    - make
+    - make install
+    - echo "Going to build APR Util"
+    - svn co -q https://svn.apache.org/repos/asf/apr/apr-util/branches/1.7.x $HOME/tmp/apr-util
+    - cd $HOME/tmp/apr-util
+    - ./buildconf --with-apr=$HOME/tmp/apr
+    - ./configure --with-apr=$HOME/tmp/apr-build/bin/apr-1-config --prefix=$HOME/tmp/apr-util-build
+    - make
+    - make install
+    - echo "Going to build HTTPD"
+    - svn co -q http://svn.apache.org/repos/asf/httpd/httpd/branches/2.4.x $HOME/tmp/httpd
+    - cd $HOME/tmp/httpd
+    - ./buildconf --with-apr=$HOME/tmp/apr --with-apr-util=$HOME/tmp/apr-util
+    - ./configure --prefix=$HOME/tmp/httpd-build --with-apr=$HOME/tmp/apr-build/bin/apr-1-config  --with-apr-util=$HOME/tmp/apr-util-build/bin/apu-1-config
+    - make
+    - make install
+
+script:
+    - echo "Going to build Tomcat Connectors"
+    - cd $CURR_PWD
+    - cd native
+    - ./buildconf.sh
+    - ./configure --with-apxs=$HOME/tmp/httpd-build/bin/apxs --prefix=$HOME/tmp/tc-connectors-build
+    - make
+    - make install
+
+after_failure:
+    - ls -la $HOME/tmp
+
+notifications:
+    email:
+        - dev@tomcat.apache.org


### PR DESCRIPTION
This TravisCI config will build `Apache ARP 1.7.x`, `Apache ARP Util 1.7.x`, `Apache HTTPD 2.4.x` and `Apache Tomcat Connectors` (mod_jk).

It should be something similar to what Gump does but I haven't seen Gump configs so far.
And Gump seems to be down at the moment: https://vmgump.apache.org/tomcat-connectors-native/