### PR TITLE
Possible issue in ajp_read_fully_from_server()

### DIFF
--- a/native/common/jk_ajp_common.c
+++ b/native/common/jk_ajp_common.c
@@ -1512,7 +1512,7 @@ static int ajp_read_fully_from_server(jk_ws_service_t *s, jk_log_context_t *l,
 
     while (rdlen < padded_len) {
         unsigned int this_time = 0;
-        if (!s->read(s, buf + rdlen, len - rdlen, &this_time)) {
+        if (!s->read(s, buf + rdlen, padded_len - rdlen, &this_time)) {
             /* Remote Client read failed.
              */
             JK_TRACE_EXIT(l);


### PR DESCRIPTION
The the outer `while`-loop was changed to respect a padded length yeas before. But according to this, imho the `read()` should append the same number of bytes as a maximum, too. If I'm wrong, please explain to me.