### PR TITLE
native/common/jk_global.h: fix compilation on musl

### DIFF
--- a/native/common/jk_global.h
+++ b/native/common/jk_global.h
@@ -148,7 +148,7 @@ extern char *strdup(const char *str);
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <sys/un.h>
-#if !defined(_OSD_POSIX) && !defined(AS400) && !defined(__CYGWIN__) && !defined(HPUX11)
+#if !defined(_OSD_POSIX) && !defined(AS400) && !defined(__CYGWIN__) && !defined(HPUX11) && !defined(PLATFORM_LINUX)
 #include <sys/socketvar.h>
 #endif
 #if !defined(HPUX11) && !defined(AS400)


### PR DESCRIPTION
On musl, sys/socketvar.h does not exist, so we need to make sure, not to use it.