### PR TITLE
correct typos

### DIFF
--- a/xdocs/ajp/ajpv13ext.xml
+++ b/xdocs/ajp/ajpv13ext.xml
@@ -41,13 +41,13 @@ ajp13 is a good protocol to link a servlet engine like tomcat to a web server li
 
 <ul>
 <li>
-use persistants connections to avoid reconnect time at each request
+use persistent connections to avoid reconnect time at each request
 </li>
 <li>
 encode many http commands to reduce stream size
 </li>
 <li>
-send to servlet engine many info from web server (like SSL certs)
+send to servlet engine much info from web server (like SSL certs)
 </li>
 </ul>
 <p>
@@ -66,7 +66,7 @@ But ajp13 lacks support for:
   indicate to the web server which URI to handle. 
   The mod_jk JkMount directive, told to web server which URI must be 
   forwarded to servlet engine.
-  A servlet engine allready knows which URI it handle and TC 3.3 is
+  A servlet engine already knows which URI it handle and TC 3.3 is
   allready capable to generate a config file for JK from the list
   of available contexts.
 </li>
@@ -91,7 +91,7 @@ But ajp13 lacks support for:
 
 <subsection name="Proposed add-ons to AJP13">
 <p>
-Let's descrive here the features and add-on that could be added to AJP13.
+Let's describe here the features and add-on that could be added to AJP13.
 Since this document is a proposal, a reasonable level of chaos must be expected at first.
 Be sure that discussion on tomcat list will help clarify points, add 
 features but the current list seems to be a 'minimun vital'


### PR DESCRIPTION
Folks, are you ok with accepting PRs for doc improvements this way? The [page discussing doc contributions](https://tomcat.apache.org/connectors-doc/miscellaneous/doccontrib.html) proposes many more steps (including "building" the docs), but is it really necessary for us just to propose simple textual changes like in this PR?

1) I do appreciate that this page I'm proposing correcting is perhaps the least important (as it's an old proposal that has barely changed in over a dozen years), but it IS listed on the left nav bar of [the connector docs pages](https://tomcat.apache.org/connectors-doc/). So people coming to the docs will see it, and could appreciate the page's typo and grammar errors being addressed.

2) Indeed, I've wanted to propose those for other pages in the docs, and I've always been discouraged given the build process, when I'd just be proposing wording changes. 

I found this section of the connector repo with the docs, and I'm hoping you may be open to at least considering proposed doc changes this way.  

3) Finally, I appreciate that some github repo maintainers have their preferences, perhaps not even caring for PRs "out of the blue". I didn't find an option here in this github repo to open an issue. And I'm hoping you wouldn't require we open a discussion thread in one of the lists, just to make such typo proposals. But I'm interested to hear if you'll prefer something other than what I've done here.

I really am just trying to help.